### PR TITLE
Potential fix for code scanning alert no. 2: Client-side cross-site scripting

### DIFF
--- a/assets/js/package.json
+++ b/assets/js/package.json
@@ -13,5 +13,8 @@
     "autoprefixer": "^10.4.12",
     "postcss": "^8.5.2",
     "tailwindcss": "^3.1.8"
+  },
+  "dependencies": {
+    "dompurify": "^3.2.4"
   }
 }

--- a/assets/js/uikit.js
+++ b/assets/js/uikit.js
@@ -1,4 +1,5 @@
 /*! UIkit 3.13.10 | https://www.getuikit.com | (c) 2014 - 2022 YOOtheme | MIT License */
+import DOMPurify from 'dompurify';
 
 (function (global, factory) {
     typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
@@ -6594,7 +6595,8 @@
           }
 
           fastdom.read(() => {
-            const targetOffset = offset($(location.hash));
+            const sanitizedHash = DOMPurify.sanitize(location.hash);
+            const targetOffset = offset($(sanitizedHash));
             const elOffset = offset(this.$el);
 
             if (this.isFixed && intersectRect(targetOffset, elOffset)) {


### PR DESCRIPTION
Potential fix for [https://github.com/Le-Xandre/Vitrine-Portfolio/security/code-scanning/2](https://github.com/Le-Xandre/Vitrine-Portfolio/security/code-scanning/2)

To fix the problem, we need to ensure that any user-provided input, such as `location.hash`, is properly sanitized before being used in the code. The best way to fix this issue is to use a library that provides robust sanitization and encoding functions. One such library is `DOMPurify`, which can sanitize HTML and prevent XSS attacks.

We will sanitize the `location.hash` value before it is used in the `fragment` function. This involves importing the `DOMPurify` library and using it to clean the `location.hash` value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
