### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete string escaping or encoding

### DIFF
--- a/assets/js/uikit.js
+++ b/assets/js/uikit.js
@@ -10955,6 +10955,7 @@
       return path.match(
       new RegExp("^" +
       pattern.
+      replace(/\\/g, '\\\\').
       replace(/\//g, '\\/').
       replace(/\*\*/g, '(\\/[^\\/]+)*').
       replace(/\*/g, '[^\\/]+').


### PR DESCRIPTION
Potential fix for [https://github.com/Le-Xandre/Vitrine-Portfolio/security/code-scanning/9](https://github.com/Le-Xandre/Vitrine-Portfolio/security/code-scanning/9)

To fix the problem, we need to ensure that backslashes in the `pattern` string are properly escaped before constructing the regular expression. This can be done by adding an additional `replace` call to escape backslashes. Specifically, we should replace each backslash (`\`) with a double backslash (`\\`). This change should be made in the `match` function in the `assets/js/uikit.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
