### PR TITLE
Potential fix for code scanning alert no. 39: DOM text reinterpreted as HTML

### DIFF
--- a/flipbook.html
+++ b/flipbook.html
@@ -633,6 +633,15 @@
                 tocContainer.classList.toggle('open');
             });
 
+            // Helper function to escape HTML entities
+            function escapeHTML(str) {
+                return str.replace(/&/g, '&amp;')
+                          .replace(/</g, '&lt;')
+                          .replace(/>/g, '&gt;')
+                          .replace(/"/g, '&quot;')
+                          .replace(/'/g, '&#39;');
+            }
+
             // Génération dynamique du sommaire
             function buildTOC() {
                 const tocContainer = document.getElementById('dynamic-toc');
@@ -641,7 +650,7 @@
                 pages.forEach((page, index) => {
                     const tocItem = document.createElement('li');
                     const pageTitle = page.querySelector('h2').innerText;
-                    tocItem.innerHTML = `<a href="javascript:void(0)" onclick="goToPage(${index + 1})">${pageTitle}</a>`;
+                    tocItem.innerHTML = `<a href="javascript:void(0)" onclick="goToPage(${index + 1})">${escapeHTML(pageTitle)}</a>`;
                     tocContainer.appendChild(tocItem);
                 });
             }


### PR DESCRIPTION
Potential fix for [https://github.com/Le-Xandre/Vitrine-Portfolio/security/code-scanning/39](https://github.com/Le-Xandre/Vitrine-Portfolio/security/code-scanning/39)

To fix the issue, the `pageTitle` variable should be sanitized or escaped before being interpolated into the HTML string. This ensures that any special characters in the `pageTitle` (e.g., `<`, `>`, `&`) are properly encoded, preventing them from being interpreted as HTML or JavaScript. A common approach is to use a utility function to escape HTML characters. Alternatively, instead of setting `innerHTML`, the DOM manipulation can be done using safer methods like `createTextNode` and `appendChild`.

The best fix here is to escape the `pageTitle` content before using it in the `innerHTML` assignment. This can be achieved by creating a helper function to encode HTML entities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
